### PR TITLE
chore(assistant): Remove model context length override 

### DIFF
--- a/ui/src/components/toolbar/assistant/llmClient.ts
+++ b/ui/src/components/toolbar/assistant/llmClient.ts
@@ -48,7 +48,6 @@ class LlmClient {
       maxRetries: 3,
       model: "keip-assistant",
       format: "json",
-      numCtx: 4096,
       temperature: 0,
     })
 


### PR DESCRIPTION
## Motivation and Context

The LLM Client hard codes the context length of the prompt. With current models this default length of 4,096 tokens will quickly lead to the prompt getting truncated. This leads to the model not having the entire context of the existing diagram when making changes.

## Details

This change removes the `numCtx` field from the LlmClient, allowing for the default context length of the model to be used.

## Does this close any open issues? If so, kindly link the relevant issues.

## Screenshots (if appropriate)

## How were the changes tested

Changes were tested by running the dev server locally with an instance of Ollama running a model with a 32k token context length. Prior to this change the context length would be stuck at 4k tokens.

## Checklist

- [x] The PR follows the branch and commit styles outlined in the [CONTRIBUTING](/codice/keip-canvas/blob/main/docs/CONTRIBUTING.md) doc
- [ ] (UI changes only) Linting and formatting checks pass locally with the new changes (`npm run precommit` from the `ui` directory)
